### PR TITLE
extend retry capabilities

### DIFF
--- a/processable.go
+++ b/processable.go
@@ -7,13 +7,30 @@ type Processable interface {
 	Msg() *sarama.ConsumerMessage
 }
 
+// Retryable is an interface for messages where saving can be retried
+type Retryable interface {
+	Processable
+	Retry()
+	Retries() int
+}
+
 // DefaultProcessable provides a vanilla implementation of the interface
 type DefaultProcessable struct {
 	msg     *sarama.ConsumerMessage
 	retries int
 }
 
-// Msg will return the enclosed saramaConsumerMessage
+// Msg returns the enclosed saramaConsumerMessage
 func (p *DefaultProcessable) Msg() *sarama.ConsumerMessage {
 	return p.msg
+}
+
+// Retry increments the number of save retries attempted
+func (p *DefaultProcessable) Retry() {
+	p.retries++
+}
+
+// Retries returns the number of save retries attempted
+func (p *DefaultProcessable) Retries() int {
+	return p.retries
 }


### PR DESCRIPTION
If we're going to put retry functionality in the `DefaultLoadSaver`, we should:

* make it compatible with all message types
* make the logging on retry/skip optional

The other option would be to remove the feature altogether, but I think it's quite useful 🙂.