### PR TITLE
split sarama implementation from group processor logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 PROJECT := go-group_processor
 PACKAGE := github.com/remerge/$(PROJECT)
 
-GOMETALINTER_OPTS = --enable-all --tests --fast -D golint -D lll
-
 include Makefile.common

--- a/Makefile.common
+++ b/Makefile.common
@@ -66,7 +66,13 @@ clean:
 
 lint: build
 	cd $(GOSRCDIR) && \
-		gometalinter --vendor --vendored-linters --deadline=$(GOTEST_TIMEOUT) $(GOMETALINTER_OPTS) $(GOMETALINTER_EXCLUDES) -D test $(GOPATHS)
+		gometalinter \
+			--vendor --vendored-linters \
+			--deadline=$(GOTEST_TIMEOUT) \
+			$(GOMETALINTER_OPTS) \
+			$(GOMETALINTER_EXCLUDES) \
+			-D test -D testify \
+			$(GOPATHS)
 
 test: lint
 	cd $(GOSRCDIR) && \

--- a/Makefile.common
+++ b/Makefile.common
@@ -66,7 +66,7 @@ clean:
 
 lint: build
 	cd $(GOSRCDIR) && \
-		gometalinter --vendor --vendored-linters --deadline=$(GOTEST_TIMEOUT) $(GOMETALINTER_OPTS) $(GOMETALINTER_EXCLUDES) $(GOPATHS)
+		gometalinter --vendor --vendored-linters --deadline=$(GOTEST_TIMEOUT) $(GOMETALINTER_OPTS) $(GOMETALINTER_EXCLUDES) -D test $(GOPATHS)
 
 test: lint
 	cd $(GOSRCDIR) && \

--- a/Makefile.common
+++ b/Makefile.common
@@ -18,6 +18,16 @@ ifeq ($(GOMETALINTER_OPTS),)
 	GOMETALINTER_OPTS=--enable-all --tests
 endif
 
+ifeq ($(GOMETALINTER_EXCLUDES),)
+	GOMETALINTER_EXCLUDES=\
+		--exclude "\.pb\.go:" \
+		--exclude "_fsm\.go:" \
+		--exclude "_easyjson\.go:" \
+		--exclude "_test\.go:.*\((lll|unparam|gocyclo)\)$$" \
+		--exclude "comment should be of the form.*\(golint\)$$" \
+		--exclude "should have comment or be unexported.*\(golint\)$$"
+endif
+
 CODE_VERSION=$(TRAVIS_COMMIT)
 ifeq ($(CODE_VERSION),)
 	CODE_VERSION=$(shell git rev-parse --short HEAD)-dev
@@ -56,7 +66,7 @@ clean:
 
 lint: build
 	cd $(GOSRCDIR) && \
-		gometalinter --deadline=$(GOTEST_TIMEOUT) $(GOMETALINTER_OPTS) $(GOPATHS)
+		gometalinter --vendor --vendored-linters --deadline=$(GOTEST_TIMEOUT) $(GOMETALINTER_OPTS) $(GOMETALINTER_EXCLUDES) $(GOPATHS)
 
 test: lint
 	cd $(GOSRCDIR) && \
@@ -64,7 +74,14 @@ test: lint
 
 bench: build
 	cd $(GOSRCDIR) && \
-		go test -bench=. -cpu 4 $(GOPATHS)
+		go test -bench=. -benchmem -cpu 32 $(GOPATHS)
+
+escape: build
+	for pkg in $(GOPATHS); do \
+		cd $(GOSRCDIR) && \
+			CGO_ENABLED=0 \
+			go build -v -gcflags '-m -m -l -e' -ldflags "$(LDFLAGS)" $$pkg; \
+	done
 
 fmt:
 	$(GOFMT) $(GOFILES)

--- a/aerospike_processor.go
+++ b/aerospike_processor.go
@@ -61,7 +61,6 @@ func (p *AerospikeProcessor) messageWorker(w *wp.Worker) {
 			if ok {
 				p.messages <- msg
 			} else {
-				p.log.Warn("trying to read from closed channel")
 				w.Done()
 				return
 			}

--- a/aerospike_processor.go
+++ b/aerospike_processor.go
@@ -1,0 +1,95 @@
+package groupprocessor
+
+import (
+	aerospike "github.com/aerospike/aerospike-client-go"
+	wp "github.com/remerge/go-worker_pool"
+)
+
+type AerospikeProcessor struct {
+	DefaultProcessor
+
+	Name      string
+	Host      *aerospike.Host
+	Namespace string
+	Set       string
+	Bins      []string
+
+	client  *aerospike.Client
+	scanner *aerospike.Recordset
+
+	messages    chan interface{}
+	messagePool *wp.Pool
+}
+
+func (p *AerospikeProcessor) New() (err error) {
+	if err = p.DefaultProcessor.New(); err != nil {
+		return err
+	}
+
+	policy := aerospike.NewClientPolicy()
+	policy.UseServicesAlternate = true
+
+	p.client, err = aerospike.NewClientWithPolicyAndHost(policy, p.Host)
+	if err != nil {
+		return err
+	}
+
+	scanPolicy := aerospike.NewScanPolicy()
+	scanPolicy.FailOnClusterChange = false
+
+	p.scanner, err = p.client.ScanAll(scanPolicy, p.Namespace, p.Set, p.Bins...)
+	if err != nil {
+		return err
+	}
+
+	p.messages = make(chan interface{})
+	p.messagePool = wp.NewPool(p.Name+".messages", 1, p.messageWorker)
+	p.messagePool.Run()
+
+	return nil
+}
+
+func (p *AerospikeProcessor) messageWorker(w *wp.Worker) {
+	for {
+		select {
+		case <-w.Closer():
+			w.Done()
+			return
+		case msg, ok := <-p.scanner.Records:
+			if ok {
+				p.messages <- msg
+			} else {
+				p.log.Warn("trying to read from closed channel")
+				w.Done()
+				return
+			}
+		case err, ok := <-p.scanner.Errors:
+			if !ok {
+				break
+			}
+			// nolint: errcheck
+			p.log.Error(err, "scan error")
+			w.Done()
+			return
+		}
+	}
+}
+
+func (p *AerospikeProcessor) Messages() chan interface{} {
+	return p.messages
+}
+
+// Close all pools, save offsets and close Kafka-connections
+func (p *AerospikeProcessor) Close() {
+	p.log.Info("message pool shutdown")
+	p.messagePool.Close()
+
+	p.log.Info("scanner shutdown")
+	// nolint: errcheck
+	p.log.Error(p.scanner.Close(), "scanner shutdown failed")
+
+	p.log.Info("aerospike client shutdown")
+	p.client.Close()
+
+	p.log.Infof("processor shutdown done")
+}

--- a/aerospike_processor.go
+++ b/aerospike_processor.go
@@ -88,7 +88,7 @@ func (p *AerospikeProcessor) Wait() {
 // Close all pools, save offsets and close Kafka-connections
 func (p *AerospikeProcessor) Close() {
 	p.log.Info("message pool shutdown")
-	p.messagePool.CloseWait()
+	p.messagePool.Close()
 
 	p.log.Info("scanner shutdown")
 	// nolint: errcheck

--- a/aerospike_processor.go
+++ b/aerospike_processor.go
@@ -22,6 +22,8 @@ type AerospikeProcessor struct {
 }
 
 func (p *AerospikeProcessor) New() (err error) {
+	p.ID = p.Name
+
 	if err = p.DefaultProcessor.New(); err != nil {
 		return err
 	}

--- a/aerospike_processor.go
+++ b/aerospike_processor.go
@@ -81,10 +81,14 @@ func (p *AerospikeProcessor) Messages() chan interface{} {
 	return p.messages
 }
 
+func (p *AerospikeProcessor) Wait() {
+	p.messagePool.Wait()
+}
+
 // Close all pools, save offsets and close Kafka-connections
 func (p *AerospikeProcessor) Close() {
 	p.log.Info("message pool shutdown")
-	p.messagePool.Close()
+	p.messagePool.CloseWait()
 
 	p.log.Info("scanner shutdown")
 	// nolint: errcheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 97e02bc271faedf6dfc7e256e63c31d089efa91bed27bc913c168c1f5e882717
-updated: 2018-01-17T19:35:53.025736523Z
+updated: 2018-01-17T21:59:01.068891325Z
 imports:
 - name: github.com/aerospike/aerospike-client-go
   version: a769a21c4817057512f54a9718872175f3a48896
@@ -46,7 +46,7 @@ imports:
 - name: github.com/remerge/go-lock_free_timer
   version: 198222a260ed873fd60f4b6014bcf4b550dcf01f
 - name: github.com/remerge/go-worker_pool
-  version: 13fd6d47efa00aa9a6adbcbbd6fdca11949bb6af
+  version: c19fd1e86fe3003c85544a9b6d059398baa828bb
 - name: github.com/remerge/go-xorshift
   version: 930dc4b93c3a7faa6e3558a5b755ec6d9b536aa4
 - name: github.com/Shopify/sarama

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,27 @@
-hash: 3d8c79e175c1018c1eb34225fe100ff9d862f8f196a3460d24555ef743652b34
-updated: 2017-12-05T13:42:33.361620412+01:00
+hash: ec55898a92bb27dd213212dd408eb54714a576144367e40208055bdb1b3d759e
+updated: 2018-01-17T13:37:18.743097254Z
 imports:
+- name: github.com/aerospike/aerospike-client-go
+  version: a769a21c4817057512f54a9718872175f3a48896
+  subpackages:
+  - internal/lua
+  - internal/lua/resources
+  - logger
+  - pkg/bcrypt
+  - pkg/ripemd160
+  - types
+  - types/atomic
+  - types/particle_type
+  - types/rand
+  - utils/buffer
 - name: github.com/cenkalti/backoff
-  version: 309aa717adbf351e92864cbedf9cca0b769a4b5a
+  version: 2ea60e5f094469f9e65adb9cd103795b73ae743e
 - name: github.com/davecgh/go-spew
   version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/eapache/go-resiliency
-  version: b1fe83b5b03f624450823b751b662259ffc6af70
+  version: ef9aaa7ea8bd2448429af1a77cf41b2b3b34bdd6
   subpackages:
   - breaker
 - name: github.com/eapache/go-xerial-snappy
@@ -18,7 +31,7 @@ imports:
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/pierrec/lz4
-  version: 08c27939df1bd95e881e2c2367a749964ad1fceb
+  version: ed8d4cc3b461464e69798080a0092bd028910298
 - name: github.com/pierrec/xxHash
   version: a0006b13c722f7f12368c00a3d3c2ae8a999a0c6
   subpackages:
@@ -33,12 +46,18 @@ imports:
 - name: github.com/remerge/go-worker_pool
   version: 13fd6d47efa00aa9a6adbcbbd6fdca11949bb6af
 - name: github.com/remerge/go-xorshift
-  version: 311573fe0a94af7b7597258aaf1fc2fbee2db0d4
+  version: 930dc4b93c3a7faa6e3558a5b755ec6d9b536aa4
 - name: github.com/Shopify/sarama
   version: 919e11f89aedafea2adbc6c2d616760efb916872
   repo: https://github.com/remerge/sarama
+- name: github.com/yuin/gopher-lua
+  version: 478861c8ce6e8c2f16d5984d5ed30c4327c70437
+  subpackages:
+  - ast
+  - parse
+  - pm
 - name: golang.org/x/net
-  version: a8b9294777976932365dabb6640cf1468d95c70f
+  version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec
   subpackages:
   - context
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ec55898a92bb27dd213212dd408eb54714a576144367e40208055bdb1b3d759e
-updated: 2018-01-17T13:37:18.743097254Z
+hash: 97e02bc271faedf6dfc7e256e63c31d089efa91bed27bc913c168c1f5e882717
+updated: 2018-01-17T19:35:53.025736523Z
 imports:
 - name: github.com/aerospike/aerospike-client-go
   version: a769a21c4817057512f54a9718872175f3a48896
@@ -43,6 +43,8 @@ imports:
   subpackages:
   - collector
   - format
+- name: github.com/remerge/go-lock_free_timer
+  version: 198222a260ed873fd60f4b6014bcf4b550dcf01f
 - name: github.com/remerge/go-worker_pool
   version: 13fd6d47efa00aa9a6adbcbbd6fdca11949bb6af
 - name: github.com/remerge/go-xorshift

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 97e02bc271faedf6dfc7e256e63c31d089efa91bed27bc913c168c1f5e882717
-updated: 2018-01-17T21:59:01.068891325Z
+updated: 2018-02-12T06:44:10.981535038Z
 imports:
 - name: github.com/aerospike/aerospike-client-go
   version: a769a21c4817057512f54a9718872175f3a48896
@@ -17,7 +17,7 @@ imports:
 - name: github.com/cenkalti/backoff
   version: 2ea60e5f094469f9e65adb9cd103795b73ae743e
 - name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
   subpackages:
   - spew
 - name: github.com/eapache/go-resiliency
@@ -37,7 +37,7 @@ imports:
   subpackages:
   - xxHash32
 - name: github.com/rcrowley/go-metrics
-  version: e181e095bae94582363434144c61a9653aff6e50
+  version: 8732c616f52954686704c8645fe1a9d59e9df7c1
 - name: github.com/remerge/cue
   version: 2bf0689b2311d580f8c7182df1161899bbfc853f
   subpackages:
@@ -50,16 +50,16 @@ imports:
 - name: github.com/remerge/go-xorshift
   version: 930dc4b93c3a7faa6e3558a5b755ec6d9b536aa4
 - name: github.com/Shopify/sarama
-  version: 919e11f89aedafea2adbc6c2d616760efb916872
+  version: 293f3e8cc48504e0ae8bc229803a8f478ae1c2cd
   repo: https://github.com/remerge/sarama
 - name: github.com/yuin/gopher-lua
-  version: 478861c8ce6e8c2f16d5984d5ed30c4327c70437
+  version: 7d7bc8747e3f614c5c587729a341fe7d8903cdb8
   subpackages:
   - ast
   - parse
   - pm
 - name: golang.org/x/net
-  version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec
+  version: f5dfe339be1d06f81b22525fe34671ee7d2c8904
   subpackages:
   - context
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,7 @@ package: github.com/remerge/go-group_processor
 import:
 - package: github.com/Shopify/sarama
   repo: https://github.com/remerge/sarama
+- package: github.com/aerospike/aerospike-client-go
 - package: github.com/cenkalti/backoff
 - package: github.com/rcrowley/go-metrics
 - package: github.com/remerge/cue

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,5 +6,6 @@ import:
 - package: github.com/cenkalti/backoff
 - package: github.com/rcrowley/go-metrics
 - package: github.com/remerge/cue
+- package: github.com/remerge/go-lock_free_timer
 - package: github.com/remerge/go-worker_pool
 - package: github.com/remerge/go-xorshift

--- a/group_processor.go
+++ b/group_processor.go
@@ -173,6 +173,9 @@ func (gp *GroupProcessor) Run() {
 
 // Close all pools
 func (gp *GroupProcessor) Close() {
+	gp.log.Info("processor shutdown")
+	gp.Processor.Close()
+
 	gp.log.Info("load pool shutdown")
 	gp.loadPool.Close()
 
@@ -181,9 +184,6 @@ func (gp *GroupProcessor) Close() {
 
 	gp.log.Info("track pool shutdown")
 	gp.trackPool.Close()
-
-	gp.log.Info("processor shutdown")
-	gp.Processor.Close()
 
 	gp.log.Infof("group processor shutdown done")
 }

--- a/group_processor.go
+++ b/group_processor.go
@@ -7,7 +7,7 @@ import (
 	wp "github.com/remerge/go-worker_pool"
 )
 
-// GroupProcessor can process messages in paralell using a LoadSaver and a
+// GroupProcessor can process messages in parallel using a LoadSaver and a
 // Processor implementation
 type GroupProcessor struct {
 	Name string

--- a/load_saver.go
+++ b/load_saver.go
@@ -1,48 +1,30 @@
 package groupprocessor
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/Shopify/sarama"
-	"github.com/cenkalti/backoff"
 	"github.com/remerge/cue"
 )
 
 type LoadSaver interface {
-	Load(*sarama.ConsumerMessage) Processable
-	Save(Processable) error
-	Done(Processable) bool
-	Fail(Processable, error) bool
+	Load(msg interface{}) Processable
+	Save(p Processable) error
+	Done(p Processable) bool
+	Fail(p Processable, err error) bool
 }
 
 type DefaultLoadSaver struct {
-	Name       string
-	Log        cue.Logger
-	MaxRetries int
-	ebo        *backoff.ExponentialBackOff
+	name string
+	log  cue.Logger
 }
 
-func (ls *DefaultLoadSaver) SetDefaults() {
-	if ls.Name == "" {
-		ls.Name = fmt.Sprintf("DefaultLoadSaver:%p", ls)
-	}
-
-	if ls.Log == nil {
-		ls.Log = cue.NewLogger(ls.Name)
-	}
-
-	if ls.ebo == nil {
-		ls.ebo = backoff.NewExponentialBackOff()
-	}
+func (ls *DefaultLoadSaver) New(name string) error {
+	ls.name = name
+	ls.log = cue.NewLogger(ls.name)
+	return nil
 }
 
-func (ls *DefaultLoadSaver) Load(
-	msg *sarama.ConsumerMessage,
-) Processable {
-	ls.SetDefaults()
+func (ls *DefaultLoadSaver) Load(value interface{}) Processable {
 	return &DefaultProcessable{
-		msg: msg,
+		value: value,
 	}
 }
 
@@ -51,57 +33,13 @@ func (ls *DefaultLoadSaver) Save(p Processable) error {
 }
 
 func (ls *DefaultLoadSaver) Done(p Processable) bool {
-	// do nothing and remove message from inflight
-	// override this method to track metrics etc
 	return true
 }
 
 func (ls *DefaultLoadSaver) Fail(p Processable, err error) bool {
-	if r, ok := p.(Retryable); ok {
-		return ls.FailWithRetry(
-			r,
-			err,
-			func(backoff time.Duration) {
-				ls.Log.WithFields(cue.Fields{
-					"msg":     r.Msg(),
-					"error":   err,
-					"retries": r.Retries(),
-					"backoff": backoff,
-				}).Warn("retrying message after failure")
-			},
-			func() {
-				ls.Log.WithFields(cue.Fields{
-					"msg": r.Msg(),
-				}).Error(err, "skipping message after all retries")
-			},
-		)
-	}
+	ls.log.WithFields(cue.Fields{
+		"value": p.Value(),
+	}).Error(err, "failed to process message")
 
-	ls.Log.WithFields(cue.Fields{
-		"msg": p.Msg(),
-	}).Error(err, "skipping non-retryable message")
-
-	return true
-}
-
-func (ls *DefaultLoadSaver) FailWithRetry(r Retryable, err error, onRetry func(time.Duration), onSkip func()) bool {
-	if r.Retries() < ls.MaxRetries {
-		r.Retry()
-
-		nextBackOff := ls.ebo.NextBackOff()
-		if onRetry != nil {
-			onRetry(nextBackOff)
-		}
-		time.Sleep(nextBackOff)
-
-		// group processor will call save again
-		return false
-	}
-
-	if onSkip != nil {
-		onSkip()
-	}
-
-	// message was processed and will be removed from inflight
-	return true
+	return false
 }

--- a/load_saver.go
+++ b/load_saver.go
@@ -13,12 +13,12 @@ type LoadSaver interface {
 
 type DefaultLoadSaver struct {
 	Name string
-	log  cue.Logger
+	Log  cue.Logger
 }
 
 func (ls *DefaultLoadSaver) New(name string) error {
 	ls.Name = name
-	ls.log = cue.NewLogger(ls.Name)
+	ls.Log = cue.NewLogger(ls.Name)
 	return nil
 }
 
@@ -38,7 +38,7 @@ func (ls *DefaultLoadSaver) Done(p Processable) bool {
 
 func (ls *DefaultLoadSaver) Fail(p Processable, err error) bool {
 	// nolint: errcheck
-	ls.log.WithFields(cue.Fields{
+	ls.Log.WithFields(cue.Fields{
 		"value": p.Value(),
 	}).Error(err, "failed to process message")
 

--- a/load_saver.go
+++ b/load_saver.go
@@ -37,6 +37,7 @@ func (ls *DefaultLoadSaver) Done(p Processable) bool {
 }
 
 func (ls *DefaultLoadSaver) Fail(p Processable, err error) bool {
+	// nolint: errcheck
 	ls.log.WithFields(cue.Fields{
 		"value": p.Value(),
 	}).Error(err, "failed to process message")

--- a/load_saver.go
+++ b/load_saver.go
@@ -12,13 +12,13 @@ type LoadSaver interface {
 }
 
 type DefaultLoadSaver struct {
-	name string
+	Name string
 	log  cue.Logger
 }
 
 func (ls *DefaultLoadSaver) New(name string) error {
-	ls.name = name
-	ls.log = cue.NewLogger(ls.name)
+	ls.Name = name
+	ls.log = cue.NewLogger(ls.Name)
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/remerge/cue/format"
 )
 
-var testLog = cue.NewLogger("test")
-
 func TestMain(m *testing.M) {
 	level := cue.DEBUG
 

--- a/processable.go
+++ b/processable.go
@@ -1,36 +1,26 @@
 package groupprocessor
 
-import "github.com/Shopify/sarama"
+import (
+	rand "github.com/remerge/go-xorshift"
+)
 
 // Processable is the message interface for the LoadSaver
 type Processable interface {
-	Msg() *sarama.ConsumerMessage
-}
-
-// Retryable is an interface for messages where saving can be retried
-type Retryable interface {
-	Processable
-	Retry()
-	Retries() int
+	Key() int
+	Value() interface{}
 }
 
 // DefaultProcessable provides a vanilla implementation of the interface
 type DefaultProcessable struct {
-	msg     *sarama.ConsumerMessage
-	retries int
+	value interface{}
 }
 
-// Msg returns the enclosed saramaConsumerMessage
-func (p *DefaultProcessable) Msg() *sarama.ConsumerMessage {
-	return p.msg
+// Key returns the message key
+func (p *DefaultProcessable) Key() int {
+	return rand.Int()
 }
 
-// Retry increments the number of save retries attempted
-func (p *DefaultProcessable) Retry() {
-	p.retries++
-}
-
-// Retries returns the number of save retries attempted
-func (p *DefaultProcessable) Retries() int {
-	return p.retries
+// Value returns the enclosed data/message
+func (p *DefaultProcessable) Value() interface{} {
+	return p.value
 }

--- a/processor.go
+++ b/processor.go
@@ -52,6 +52,7 @@ func (p *DefaultProcessor) OnRetry(processable Processable) {
 }
 
 func (p *DefaultProcessor) OnSkip(processable Processable, err error) {
+	// nolint: errcheck
 	p.log.WithFields(cue.Fields{
 		"value": processable.Value(),
 	}).Error(err, "skipping message after all retries")

--- a/processor.go
+++ b/processor.go
@@ -1,0 +1,64 @@
+package groupprocessor
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/remerge/cue"
+)
+
+type Processor interface {
+	Messages() chan interface{}
+	OnLoad(Processable)
+	OnProcessed(Processable)
+	OnRetry(Processable)
+	OnSkip(Processable, error)
+	OnTrack()
+	Close()
+}
+
+type DefaultProcessor struct {
+	ebo *backoff.ExponentialBackOff
+	log cue.Logger
+}
+
+func (p *DefaultProcessor) New() (err error) {
+	p.ebo = backoff.NewExponentialBackOff()
+	p.log = cue.NewLogger("DefaultProcessor")
+	return nil
+}
+
+func (p *DefaultProcessor) OnLoad(processable Processable) {
+	p.log.WithFields(cue.Fields{
+		"value": processable.Value(),
+	}).Debug("loaded message")
+}
+
+func (p *DefaultProcessor) OnProcessed(processable Processable) {
+	p.log.WithFields(cue.Fields{
+		"value": processable.Value(),
+	}).Debug("processed message")
+}
+
+func (p *DefaultProcessor) OnRetry(processable Processable) {
+	backoff := p.ebo.NextBackOff()
+
+	p.log.WithFields(cue.Fields{
+		"value":   processable.Value(),
+		"backoff": backoff,
+	}).Warn("retrying failed message")
+
+	time.Sleep(backoff)
+}
+
+func (p *DefaultProcessor) OnSkip(processable Processable, err error) {
+	p.log.WithFields(cue.Fields{
+		"value": processable.Value(),
+	}).Error(err, "skipping message after all retries")
+}
+
+func (p *DefaultProcessor) OnTrack() {
+}
+
+func (p *DefaultProcessor) Close() {
+}

--- a/processor.go
+++ b/processor.go
@@ -18,13 +18,14 @@ type Processor interface {
 }
 
 type DefaultProcessor struct {
+	ID  string
 	ebo *backoff.ExponentialBackOff
 	log cue.Logger
 }
 
 func (p *DefaultProcessor) New() (err error) {
 	p.ebo = backoff.NewExponentialBackOff()
-	p.log = cue.NewLogger("DefaultProcessor")
+	p.log = cue.NewLogger(p.ID)
 	return nil
 }
 

--- a/processor.go
+++ b/processor.go
@@ -14,6 +14,7 @@ type Processor interface {
 	OnRetry(Processable)
 	OnSkip(Processable, error)
 	OnTrack()
+	Wait()
 	Close()
 }
 

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -147,6 +147,10 @@ func (p *SaramaProcessor) Messages() chan interface{} {
 	return p.messages
 }
 
+func (p *SaramaProcessor) Wait() {
+	p.messagePool.Wait()
+}
+
 func (p *SaramaProcessor) OnLoad(processable Processable) {
 	msg := processable.Value().(*sarama.ConsumerMessage)
 

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -1,0 +1,222 @@
+package groupprocessor
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/remerge/cue"
+	wp "github.com/remerge/go-worker_pool"
+)
+
+// SaramaProcessor is a Processor that reads messages from a Kafka topic with a
+// group consumer and tracks offsets of processed messages
+type SaramaProcessor struct {
+	DefaultProcessor
+
+	sync.RWMutex
+
+	Name     string
+	Brokers  string
+	Topic    string
+	GroupGen int
+
+	Config *sarama.Config
+
+	client   sarama.Client
+	consumer sarama.ConsumerGroup
+
+	messages    chan interface{}
+	messagePool *wp.Pool
+
+	notifyPool *wp.Pool
+
+	loadedOffsets   map[int32]int64
+	inFlightOffsets map[int32]map[int64]*sarama.ConsumerMessage
+
+	log cue.Logger
+}
+
+// New initializes the SaramaProcessor once it's instantiated
+func (p *SaramaProcessor) New() (err error) {
+	if err := p.DefaultProcessor.New(); err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("%v.%v", p.Name, p.Topic)
+
+	p.log = cue.NewLogger(id)
+
+	if p.Config == nil {
+		p.Config = sarama.NewConfig()
+		p.Config.Consumer.MaxProcessingTime = 30 * time.Second
+		p.Config.Consumer.Offsets.Initial = sarama.OffsetOldest
+		p.Config.Group.Return.Notifications = true
+	}
+
+	p.Config.ClientID = id
+	p.Config.Version = sarama.V0_10_0_0
+
+	p.client, err = sarama.NewClient(
+		strings.Split(p.Brokers, ","),
+		p.Config,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	group := fmt.Sprintf("%s.%s.%d", p.Name, p.Topic, p.GroupGen)
+	p.consumer, err = sarama.NewConsumerGroupFromClient(
+		p.client,
+		group,
+		[]string{p.Topic},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	p.messages = make(chan interface{})
+	p.messagePool = wp.NewPool(id, 1, p.messageWorker)
+	p.messagePool.Run()
+
+	p.notifyPool = wp.NewPool(id, 1, p.notifyWorker)
+	p.notifyPool.Run()
+
+	p.loadedOffsets = make(map[int32]int64)
+	p.inFlightOffsets = make(map[int32]map[int64]*sarama.ConsumerMessage)
+
+	return nil
+}
+
+//func msgID(processable Processable) int {
+//    key := processable.Msg().Key
+
+//    if key != nil && len(key) > 0 {
+//        hash := fnv.New64a()
+//        // #nosec
+//        hash.Write(key)
+//        return int(hash.Sum64())
+//    }
+
+//    return rand.Int()
+//}
+
+func (p *SaramaProcessor) notifyWorker(w *wp.Worker) {
+	for {
+		select {
+		case <-w.Closer():
+			w.Done()
+			return
+		case n, ok := <-p.consumer.Notifications():
+			if !ok {
+				break
+			}
+			p.log.WithFields(cue.Fields{
+				"added":    n.Claimed,
+				"current":  n.Current,
+				"released": n.Released,
+			}).Infof("group rebalance")
+		}
+	}
+}
+
+func (p *SaramaProcessor) messageWorker(w *wp.Worker) {
+	for {
+		select {
+		case <-w.Closer():
+			w.Done()
+			return
+		case msg, ok := <-p.consumer.Messages():
+			if ok {
+				p.messages <- msg
+			} else {
+				p.log.Warn("trying to read from closed channel")
+				w.Done()
+				return
+			}
+		}
+	}
+}
+
+func (p *SaramaProcessor) Messages() chan interface{} {
+	return p.messages
+}
+
+func (p *SaramaProcessor) OnLoad(processable Processable) {
+	msg := processable.Value().(*sarama.ConsumerMessage)
+
+	p.Lock()
+	defer p.Unlock()
+
+	if p.loadedOffsets[msg.Partition] < msg.Offset {
+		p.loadedOffsets[msg.Partition] = msg.Offset
+	}
+
+	if p.inFlightOffsets[msg.Partition] == nil {
+		p.inFlightOffsets[msg.Partition] = make(
+			map[int64]*sarama.ConsumerMessage,
+		)
+	}
+
+	p.inFlightOffsets[msg.Partition][msg.Offset] = msg
+}
+
+func (p *SaramaProcessor) OnProcessed(processable Processable) {
+	msg := processable.Value().(*sarama.ConsumerMessage)
+
+	p.Lock()
+	defer p.Unlock()
+
+	delete(p.inFlightOffsets[msg.Partition], msg.Offset)
+}
+
+func (p *SaramaProcessor) OnTrack() {
+	p.RLock()
+	defer p.RUnlock()
+
+	offsets := make(map[int32]int64)
+
+	// when all messages have been processed p.inFlightOffsets is empty, so we
+	// use the latest loaded offset for commit instead
+	for partition, offset := range p.loadedOffsets {
+		offsets[partition] = offset
+	}
+
+	for partition, offsetMap := range p.inFlightOffsets {
+		for offset := range offsetMap {
+			if offsets[partition] == 0 || offset < offsets[partition] {
+				offsets[partition] = offset
+			}
+		}
+	}
+
+	for partition, offset := range offsets {
+		p.consumer.MarkOffset(p.Topic, partition, offset, "")
+	}
+}
+
+// Close all pools, save offsets and close Kafka-connections
+func (p *SaramaProcessor) Close() {
+	p.log.Info("message pool shutdown")
+	p.messagePool.Close()
+
+	p.log.Info("message pool shutdown")
+	p.notifyPool.Close()
+
+	p.log.Info("save consumer offsets")
+	p.OnTrack()
+
+	p.log.Info("consumer group shutdown")
+	// #nosec
+	p.log.Error(p.consumer.Close(), "consumer group shutdown failed")
+
+	p.log.Info("kafka client shutdown")
+	// #nosec
+	p.log.Error(p.client.Close(), "kafka client shutdown failed")
+
+	p.log.Infof("processor shutdown done")
+}

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -126,7 +126,6 @@ func (p *SaramaProcessor) messageWorker(w *wp.Worker) {
 			if ok {
 				p.messages <- msg
 			} else {
-				p.log.Warn("trying to read from closed channel")
 				w.Done()
 				return
 			}
@@ -206,9 +205,6 @@ func (p *SaramaProcessor) OnTrack() {
 
 // Close all pools, save offsets and close Kafka-connections
 func (p *SaramaProcessor) Close() {
-	p.log.Info("message pool shutdown")
-	p.messagePool.Close()
-
 	p.log.Info("save consumer offsets")
 	p.OnTrack()
 
@@ -219,6 +215,9 @@ func (p *SaramaProcessor) Close() {
 	p.log.Info("kafka client shutdown")
 	// nolint: errcheck
 	p.log.Error(p.client.Close(), "kafka client shutdown failed")
+
+	p.log.Info("message pool shutdown")
+	p.messagePool.Close()
 
 	p.log.Infof("processor shutdown done")
 }

--- a/sarama_processor_test.go
+++ b/sarama_processor_test.go
@@ -83,7 +83,7 @@ func TestGroupProcessor(t *testing.T) {
 		Processor:     p,
 		NumLoadWorker: 4,
 		NumSaveWorker: 4,
-		TrackInterval: 10,
+		TrackInterval: 1 * time.Second,
 		LoadSaver:     tls,
 	}
 
@@ -104,7 +104,7 @@ func TestGroupProcessor(t *testing.T) {
 
 	assertEqual(t, err, nil, "Unexpected error in SendMessage: %v", err)
 
-	timeout := time.After(time.Second * 5)
+	timeout := time.After(1 * time.Second)
 	var msg string
 
 L:
@@ -172,7 +172,7 @@ func TestGroupProcessorWithErrorRetry(t *testing.T) {
 		MaxRetries:    1,
 		NumLoadWorker: 4,
 		NumSaveWorker: 4,
-		TrackInterval: 10,
+		TrackInterval: 1 * time.Second,
 		LoadSaver:     tls,
 	}
 
@@ -193,7 +193,7 @@ func TestGroupProcessorWithErrorRetry(t *testing.T) {
 
 	assertEqual(t, err, nil, "Unexpected error in SendMessage: %v", err)
 
-	timeout := time.After(time.Second * 5)
+	timeout := time.After(1 * time.Second)
 	var tp *testProcessable
 
 L:
@@ -242,7 +242,7 @@ func TestGroupProcessor_with_CustomConfig(t *testing.T) {
 		Processor:     p,
 		NumLoadWorker: 4,
 		NumSaveWorker: 4,
-		TrackInterval: 10,
+		TrackInterval: 1 * time.Second,
 		LoadSaver:     tls,
 	}
 
@@ -268,7 +268,7 @@ func TestGroupProcessor_with_CustomConfig(t *testing.T) {
 
 	assertEqual(t, err, nil, "Unexpected error in SendMessage: %v", err)
 
-	timeout := time.After(time.Second * 5)
+	timeout := time.After(1 * time.Second)
 	var msg string
 
 L:

--- a/sarama_processor_test.go
+++ b/sarama_processor_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 type testProcessable struct {
-	DefaultProcessable
+	SaramaProcessable
 	retries int
 }
 
 type testLoadSaver struct {
-	DefaultLoadSaver
+	SaramaLoadSaver
 	channel chan string
 }
 
 func (ls *testLoadSaver) New(name string) error {
-	if err := ls.DefaultLoadSaver.New(name); err != nil {
+	if err := ls.SaramaLoadSaver.New(name); err != nil {
 		return err
 	}
 
@@ -31,26 +31,26 @@ func (ls *testLoadSaver) New(name string) error {
 
 func (ls *testLoadSaver) Load(value interface{}) Processable {
 	return &testProcessable{
-		DefaultProcessable: DefaultProcessable{
-			value: value,
+		SaramaProcessable: SaramaProcessable{
+			value: value.(*sarama.ConsumerMessage),
 		},
 	}
 }
 
 func (ls *testLoadSaver) Save(p Processable) error {
 	ls.channel <- string(p.Value().(*sarama.ConsumerMessage).Value)
-	return ls.DefaultLoadSaver.Save(p)
+	return ls.SaramaLoadSaver.Save(p)
 }
 
 func (ls *testLoadSaver) Done(p Processable) bool {
 	ls.log.Infof("processed msg=%v", p.Value())
-	return ls.DefaultLoadSaver.Done(p)
+	return ls.SaramaLoadSaver.Done(p)
 }
 
 func (ls *testLoadSaver) Fail(p Processable, err error) bool {
 	tp := p.(*testProcessable)
 	tp.retries++
-	return ls.DefaultLoadSaver.Fail(p, err)
+	return ls.SaramaLoadSaver.Fail(p, err)
 }
 
 func assertEqual(t *testing.T, a interface{}, b interface{}, message string, args ...interface{}) {
@@ -128,7 +128,7 @@ type testLoadErrorSaver struct {
 }
 
 func (ls *testLoadErrorSaver) New(name string) error {
-	if err := ls.DefaultLoadSaver.New(name); err != nil {
+	if err := ls.SaramaLoadSaver.New(name); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This split will allow us to use the group processor for other sources and sinks than kafka/sarama, e.g. aerospike. It is still WIP.