### PR TITLE
use debug level for logging metrics

### DIFF
--- a/group_processor.go
+++ b/group_processor.go
@@ -75,7 +75,7 @@ func (gp *GroupProcessor) logMetrics() {
 		"process_m1":  int64(gp.processed.Rate1()),
 		"retries":     gp.retries.Count(),
 		"skipped":     gp.skipped.Count(),
-	}).Infof("messages")
+	}).Debug("messages")
 }
 
 func (gp *GroupProcessor) trackWorker(w *wp.Worker) {


### PR DESCRIPTION
This logging is performed based on the `TrackInterval`, which will most likely be low (i.e. 1s) for Kafka processors. If we change the level to debug, we avoid having to adapt the interface.