### PR TITLE
save offsets on skip

### DIFF
--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -233,10 +233,12 @@ func (p *SaramaProcessor) OnLoad(processable Processable) {
 
 func (p *SaramaProcessor) OnProcessed(processable Processable) {
 	p.processableFinished(processable)
+	p.DefaultProcessor.OnProcessed(processable)
 }
 
 func (p *SaramaProcessor) OnSkip(processable Processable, err error) {
 	p.processableFinished(processable)
+	p.DefaultProcessor.OnSkip(processable, err)
 }
 
 // processableFinished is called either once the processable is successfully

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -232,6 +232,16 @@ func (p *SaramaProcessor) OnLoad(processable Processable) {
 }
 
 func (p *SaramaProcessor) OnProcessed(processable Processable) {
+	p.processableFinished(processable)
+}
+
+func (p *SaramaProcessor) OnSkip(processable Processable, err error) {
+	p.processableFinished(processable)
+}
+
+// processableFinished is called either once the processable is successfully
+// processed (OnProcessed) or when all of the retries were exhausted (OnSkip).
+func (p *SaramaProcessor) processableFinished(processable Processable) {
 	msg := processable.Value().(*sarama.ConsumerMessage)
 
 	p.Lock()


### PR DESCRIPTION
There are two outcomes for a message or "processable": either it's processed successfully and `OnProcessed` is called, or it exhausts all of the retries (if any) and `OnSkip` is called. In the latter case, we don't remove the offset from the in flight offsets. This results in no subsequent offsets for that partition being marked.