### PR TITLE
3950 shutdown fixes

### DIFF
--- a/group_processor.go
+++ b/group_processor.go
@@ -181,21 +181,6 @@ func (gp *GroupProcessor) Run() {
 	gp.loadPool.Run()
 	go func() {
 		gp.exitErr = gp.Processor.Wait()
-
-		// this workaround old implementation of go-service that tracks
-		// for working goroutines. can be deleted after services are migrated
-		// to a new go-service implementation.
-		poolsClosedCh := make(chan struct{})
-		go func() {
-			gp.loadPool.Close()
-			gp.savePool.Close()
-			close(poolsClosedCh)
-		}()
-		select {
-		case <-poolsClosedCh:
-		case <-time.After(time.Second * 30):
-		}
-
 		gp.wg.Done()
 	}()
 }

--- a/group_processor.go
+++ b/group_processor.go
@@ -193,7 +193,7 @@ func (gp *GroupProcessor) Run() {
 		}()
 		select {
 		case <-poolsClosedCh:
-		case <-time.After(time.Second*30):
+		case <-time.After(time.Second * 30):
 		}
 
 		gp.wg.Done()

--- a/group_processor.go
+++ b/group_processor.go
@@ -176,21 +176,26 @@ func (gp *GroupProcessor) saveWorker(w *wp.Worker) {
 
 // Run the GroupProcessor consisting of trackPool, savePool and loadPool
 func (gp *GroupProcessor) Run() {
-	gp.wg.Add(3)
+	gp.wg.Add(1)
 	gp.savePool.Run()
 	gp.loadPool.Run()
 	go func() {
-		gp.savePool.Wait()
-		gp.wg.Done()
-	}()
-	go func() {
-		gp.loadPool.Wait()
-		gp.wg.Done()
-	}()
-	go func() {
 		gp.exitErr = gp.Processor.Wait()
-		gp.loadPool.Close()
-		gp.savePool.Close()
+
+		// this workaround old implementation of go-service that tracks
+		// for working goroutines. can be deleted after services are migrated
+		// to a new go-service implementation.
+		poolsClosedCh := make(chan struct{})
+		go func() {
+			gp.loadPool.Close()
+			gp.savePool.Close()
+			close(poolsClosedCh)
+		}()
+		select {
+		case <-poolsClosedCh:
+		case <-time.After(time.Second*30):
+		}
+
 		gp.wg.Done()
 	}()
 }

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -113,6 +113,7 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 						case sarama.ErrRequestTimedOut:
 							return nil
 						default:
+							p.log.Warnf("unrecoverable consume error %v", kafkaErr)
 							return e
 						}
 					}


### PR DESCRIPTION
This is fix for time bomb.

1. Ensure close regardless possibly blocked worker pools 
1. Ensure that all kinds of errors are returned by `Wait()`
1. Log unrecoverable consumer errors