### PR TITLE
assert all consume and session errors as recoverable

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -65,7 +65,7 @@ func Consume(ctx context.Context, saramaConfig *sarama.Config, brokers []string,
 						return
 					}
 					if fnErr := config.OnError(consumeErr); fnErr != nil {
-						c.consumeErr = fmt.Errorf("consume: %s", fnErr)
+						c.consumeErr = fmt.Errorf("consume: %s", consumeErr)
 						c.cancelFn()
 						return
 					}
@@ -82,7 +82,7 @@ func Consume(ctx context.Context, saramaConfig *sarama.Config, brokers []string,
 			default:
 			}
 			sessErr := group.Consume(c.ctx, config.Topics, config.Handler)
-			if sessErr != nil {
+			if fnErr := config.OnError(sessErr); fnErr != nil {
 				c.sessionErr = fmt.Errorf("session: %s", sessErr)
 				c.cancelFn()
 				return

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/Shopify/sarama v1.22.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/davecgh/go-spew v1.1.1
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/remerge/cue v0.0.0-20180404154012-5ce627d813ef

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -117,7 +117,8 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 					if kafkaErr, isKafkaErr := err1.Err.(sarama.KError); isKafkaErr {
 						switch kafkaErr {
 						case sarama.ErrRequestTimedOut,
-							sarama.ErrRebalanceInProgress:
+							sarama.ErrRebalanceInProgress,
+							sarama.ErrOffsetsLoadInProgress:
 							return nil
 						default:
 							p.log.Warnf("unrecoverable consume error %v", kafkaErr)

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -120,7 +120,8 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 						case sarama.ErrRequestTimedOut,
 							sarama.ErrRebalanceInProgress,
 							sarama.ErrOffsetsLoadInProgress,
-							sarama.ErrNotCoordinatorForConsumer:
+							sarama.ErrNotCoordinatorForConsumer,
+							sarama.ErrUnknownMemberId:
 							p.log.Warnf("recoverable consume error %v", kafkaErr)
 							return nil
 						default:

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -110,6 +110,7 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 				// detect generic errors
 				switch err {
 				case io.EOF:
+					p.log.Warnf("recoverable consume error %v", err)
 					return nil
 				}
 				switch err1 := e.(type) {
@@ -120,6 +121,7 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 							sarama.ErrRebalanceInProgress,
 							sarama.ErrOffsetsLoadInProgress,
 							sarama.ErrNotCoordinatorForConsumer:
+							p.log.Warnf("recoverable consume error %v", kafkaErr)
 							return nil
 						default:
 							p.log.Warnf("unrecoverable consume error %v", kafkaErr)

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -118,7 +118,8 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 						switch kafkaErr {
 						case sarama.ErrRequestTimedOut,
 							sarama.ErrRebalanceInProgress,
-							sarama.ErrOffsetsLoadInProgress:
+							sarama.ErrOffsetsLoadInProgress,
+							sarama.ErrNotCoordinatorForConsumer:
 							return nil
 						default:
 							p.log.Warnf("unrecoverable consume error %v", kafkaErr)

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -110,7 +110,8 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 				case *sarama.ConsumerError:
 					if kafkaErr, isKafkaErr := err1.Err.(sarama.KError); isKafkaErr {
 						switch kafkaErr {
-						case sarama.ErrRequestTimedOut:
+						case sarama.ErrRequestTimedOut,
+							sarama.ErrRebalanceInProgress:
 							return nil
 						default:
 							p.log.Warnf("unrecoverable consume error %v", kafkaErr)

--- a/sarama_processor.go
+++ b/sarama_processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"strings"
 	"time"
 
@@ -106,6 +107,11 @@ func NewSaramaProcessor(config *SaramaProcessorConfig) (p *SaramaProcessor, err 
 			Topics:  []string{p.Topic},
 			Handler: p.handler,
 			OnError: func(e error) error {
+				// detect generic errors
+				switch err {
+				case io.EOF:
+					return nil
+				}
 				switch err1 := e.(type) {
 				case *sarama.ConsumerError:
 					if kafkaErr, isKafkaErr := err1.Err.(sarama.KError); isKafkaErr {


### PR DESCRIPTION
[trello](https://trello.com/c/cF8SftOz/481-do-not-crash-services-which-uses-go-group-processor-on-recoverable-errors)