### PR TITLE
use warn level for skipped messages

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -44,10 +44,10 @@ func (p *DefaultProcessor) OnRetry(processable Processable) {
 }
 
 func (p *DefaultProcessor) OnSkip(processable Processable, err error) {
-	// nolint: errcheck
 	p.log.WithFields(cue.Fields{
+		"error": err,
 		"value": processable.Value(),
-	}).Error(err, "skipping message after all retries")
+	}).Warn("skipping message after all retries")
 }
 
 func (p *DefaultProcessor) Close() {


### PR DESCRIPTION
We already have a metric for skipped messages, so we can build alerts around this rather than logging every single skipped message as an error.
